### PR TITLE
Manual compilation and compiling in release mode

### DIFF
--- a/OpenApiLINQPadDriver/ClientGenerator.cs
+++ b/OpenApiLINQPadDriver/ClientGenerator.cs
@@ -4,20 +4,20 @@ using System.Linq;
 using static OpenApiLINQPadDriver.ParameterDescriptors;
 namespace OpenApiLINQPadDriver;
 
-public static class ClientGenerator
+internal static class ClientGenerator
 {
     public const string PrepareRequestFunctionName = "PrepareRequestFunction";
 
-    public static string SingleClientFromOperationIdOperationNameGenerator(string nameSpace, string typeName)
-        => GetClientPartial(nameSpace, typeName);
+    public static string SingleClientFromOperationIdOperationNameGenerator(TypeDescriptor type)
+        => GetClientPartial(type.NameSpace, type.Name);
 
-    public static string MultipleClientsFromOperationIdOperationNameGenerator(ICollection<string> clientTypeNames, string nameSpace, string typeName)
+    public static string MultipleClientsFromOperationIdOperationNameGenerator(ICollection<string> clientTypeNames, TypeDescriptor type)
     {
         return $@"
 
-namespace {nameSpace}
+namespace {type.NameSpace}
 {{
-    public partial class {typeName}
+    public partial class {type.Name}
     {{
 {GenerateFields()}
 
@@ -33,14 +33,14 @@ namespace {nameSpace}
         }}
 
 
-        public {typeName}({HttpClient.FullTypeName} {HttpClient.ParameterName})
+        public {type.Name}({HttpClient.FullTypeName} {HttpClient.ParameterName})
         {{
 {GenerateInitializations()}
         }}
     }}
 }}
 
-{string.Join(Environment.NewLine, clientTypeNames.Select(clientTypeName => GetClientPartial(nameSpace, clientTypeName)))}";
+{string.Join(Environment.NewLine, clientTypeNames.Select(clientTypeName => GetClientPartial(type.NameSpace, clientTypeName)))}";
 
         string GenerateFields()
             => string.Join(Environment.NewLine,

--- a/OpenApiLINQPadDriver/Compilation/CompilationOutput.cs
+++ b/OpenApiLINQPadDriver/Compilation/CompilationOutput.cs
@@ -1,0 +1,24 @@
+﻿using System.Linq;
+
+namespace OpenApiLINQPadDriver.Compilation;
+internal sealed class CompilationOutput
+{
+    public string[] References { get; }
+
+    public bool Successful { get; }
+
+    public string[] Errors { get; }
+
+    public string[] Warnings { get; }
+
+    public string? SourceCodeAroundFirstError { get; }
+
+    public CompilationOutput(string[] errors, string[] warnings, string[] references, string? sourceCodeAroundFirstError = null)
+    {
+        Successful = !errors.Any();
+        Errors = errors;
+        Warnings = warnings;
+        References = references;
+        SourceCodeAroundFirstError = sourceCodeAroundFirstError;
+    }
+}

--- a/OpenApiLINQPadDriver/Compilation/DiagnosticsExtensions.cs
+++ b/OpenApiLINQPadDriver/Compilation/DiagnosticsExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace OpenApiLINQPadDriver.Compilation;
+internal static class DiagnosticsExtensions
+{
+    public static string[] GetErrors(this IEnumerable<Diagnostic> diagnostics)
+        => diagnostics.Get(DiagnosticSeverity.Error);
+
+    public static string[] GetWarnings(this IEnumerable<Diagnostic> diagnostics)
+        => diagnostics.Get(DiagnosticSeverity.Warning);
+
+    private static string[] Get(this IEnumerable<Diagnostic> diagnostics, DiagnosticSeverity severity)
+        => diagnostics.Where(d => d.Severity == severity).Select(e => e.ToString()).ToArray();
+}

--- a/OpenApiLINQPadDriver/Compilation/RoslynHelper.cs
+++ b/OpenApiLINQPadDriver/Compilation/RoslynHelper.cs
@@ -1,0 +1,80 @@
+﻿using LINQPad.Extensibility.DataContext;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenApiLINQPadDriver.Compilation;
+internal static class RoslynHelper
+{
+    private static readonly Dictionary<string, ReportDiagnostic> WarningOptions = new()
+    {
+        { "CS1591", ReportDiagnostic.Suppress } //Missing XML comment for publicly visible type or member 'Type_or_Member'
+    };
+    public static CompilationOutput CompileSource(CompilationInput input, bool buildInRelease)
+    {
+        var optimization = buildInRelease ? OptimizationLevel.Release : OptimizationLevel.Debug;
+        var syntaxTrees = input.SourceCode
+            // https://forum.linqpad.net/discussion/3002/linqpad-seems-to-ignore-and-tags-in-documentation-comments#latest
+            .Select(source => source.Replace("<remarks>", "<summary>").Replace("</remarks>", "</summary>"))
+            .Select(source => CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest, DocumentationMode.Diagnose))).ToArray();
+
+        var executableReferences = input.FilePathsToReference.Select(fileReference => MetadataReference.CreateFromFile(fileReference));
+
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(input.OutputPath);
+
+        var options = new CSharpCompilationOptions(outputKind: OutputKind.DynamicallyLinkedLibrary,
+            xmlReferenceResolver: XmlFileResolver.Default,
+            nullableContextOptions: NullableContextOptions.Enable,
+            optimizationLevel: optimization,
+            metadataImportOptions: MetadataImportOptions.Public,
+            specificDiagnosticOptions: WarningOptions
+        );
+
+        var csharpCompilation = CSharpCompilation.Create(fileNameWithoutExtension, syntaxTrees, executableReferences, options);
+        var diagnostics = csharpCompilation.GetDiagnostics();
+        var errorsFromCompilation = diagnostics.GetErrors();
+        if (errorsFromCompilation.Any())
+        {
+            var diagnosticsFromCompilation = diagnostics.GetWarnings();
+            var sourceCodeAroundFirstError = GetSurroundingSource(diagnostics.First(d => d.Severity == DiagnosticSeverity.Error).Location);
+            var compilationOutput = new CompilationOutput(errorsFromCompilation, diagnosticsFromCompilation, input.FilePathsToReference, sourceCodeAroundFirstError);
+
+            return compilationOutput;
+        }
+
+        var emitResult = csharpCompilation.Emit(input.OutputPath, xmlDocPath: GetXmlDocumentFileNameWithPath(input.OutputPath, fileNameWithoutExtension));
+        var errors = emitResult.Diagnostics.GetErrors();
+        var warnings = emitResult.Diagnostics.GetWarnings();
+
+        var output = new CompilationOutput(errors, warnings, input.FilePathsToReference);
+
+        return output;
+
+        static string GetXmlDocumentFileNameWithPath(string outputPath, string fileNameWithoutExtension)
+        {
+            var dllDirectory = Path.GetDirectoryName(outputPath);
+
+            return Path.Join(dllDirectory, fileNameWithoutExtension) + ".xml";
+        }
+    }
+
+    private static string? GetSurroundingSource(Location? location)
+    {
+        if (location == null || !location.IsInSource)
+            return null;
+
+        var str = location.SourceTree.ToString();
+        var mappedLineSpan = location.GetMappedLineSpan();
+        var startLinePosition = mappedLineSpan.StartLinePosition;
+        var line = startLinePosition.Line;
+        if (line < 0)
+            return null;
+        var source = str.Split('\n');
+        var count = Math.Max(0, line - 5);
+        var num = Math.Min(source.Length - 1, line + 5);
+        return string.Concat(source.Skip(count).Take(line - count).Select(l => l.Replace("\r", string.Empty) + "\r\n")) + "===>" + source[line].Replace("\r", string.Empty) + "<===" + string.Concat(source.Skip(line + 1).Take(num - line).Select(l => "\r\n" + l.Replace("\r", string.Empty)));
+    }
+}

--- a/OpenApiLINQPadDriver/ConnectionDialog.xaml
+++ b/OpenApiLINQPadDriver/ConnectionDialog.xaml
@@ -95,7 +95,7 @@
                     <TextBlock Style="{StaticResource TextBlockHyperlinkContainer}">
                         <Hyperlink Name="GetOpenApiJsonHyperlink"
                                    Style="{StaticResource StyledHyperlink}" 
-                                   TextDecorations=""
+                                   TextDecorations="None"
                                    Click="GetOpenApiJsonHyperlink_OnClick"
                                    >
                             <Run Text="Get from disk" />
@@ -114,7 +114,7 @@
                     <TextBlock Style="{StaticResource TextBlockHyperlinkContainer}">
                         <Hyperlink Name="DownloadApiUriHyperlink"
                                    Style="{StaticResource StyledHyperlink}" 
-                                   TextDecorations=""
+                                   TextDecorations="None"
                                    Click="DownloadApiUriHyperlink_OnClick" 
                                    IsEnabled ="{Binding IsOpenApiDocumentUriValid, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}">
                             <Run Text="Get from swagger.json" />
@@ -167,6 +167,9 @@
 
                 <StackPanel Grid.Row="3" Grid.Column="0" Style="{StaticResource CheckBoxStackPanelStyle}">
                     <CheckBox IsChecked="{Binding GenerateSyncMethods}" Content="Generate sync _methods" ToolTip="Generate synchronous methods"/>
+                </StackPanel>
+                <StackPanel Grid.Row="3" Grid.Column="1" Style="{StaticResource CheckBoxStackPanelStyle}">
+                    <CheckBox IsChecked="{Binding BuildInRelease}" Content="Build in _Release" ToolTip="Build generated code in Release"/>
                 </StackPanel>
             </Grid>
         </GroupBox>

--- a/OpenApiLINQPadDriver/ConnectionDialog.xaml.cs
+++ b/OpenApiLINQPadDriver/ConnectionDialog.xaml.cs
@@ -59,6 +59,7 @@ internal partial class ConnectionDialog
             hyperlink.IsEnabled = true;
         }
     }
+
     private async void DownloadApiUriHyperlink_OnClick(object sender, RoutedEventArgs e)
     {
         var hyperlink = (Hyperlink)sender;

--- a/OpenApiLINQPadDriver/ContextConstructorParameters.cs
+++ b/OpenApiLINQPadDriver/ContextConstructorParameters.cs
@@ -1,8 +1,7 @@
 ﻿using LINQPad.Extensibility.DataContext;
 
 namespace OpenApiLINQPadDriver;
-
-public static class ParameterDescriptors
+internal static class ParameterDescriptors
 {
     public static readonly ParameterDescriptor HttpClient = new("httpClient", $"{nameof(System)}.{nameof(System.Net)}.{nameof(System.Net.Http)}.{nameof(System.Net.Http.HttpClient)}");
     public static readonly ParameterDescriptor HttpRequestMessage = new("httpRequestMessage", $"{nameof(System)}.{nameof(System.Net)}.{nameof(System.Net.Http)}.{nameof(System.Net.Http.HttpRequestMessage)}");

--- a/OpenApiLINQPadDriver/ExplorerItemHelper.cs
+++ b/OpenApiLINQPadDriver/ExplorerItemHelper.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using LINQPad.Extensibility.DataContext;
+
+namespace OpenApiLINQPadDriver;
+internal static class ExplorerItemHelper
+{
+    public static ExplorerItem CreateForTimeMeasurement()
+        => new("Execution Times", ExplorerItemKind.Schema, ExplorerIcon.Box)
+        {
+            Children = new List<ExplorerItem>()
+        };
+
+    public static ExplorerItem CreateForCompilationErrors(IReadOnlyCollection<string> errors)
+        => CreateForCompilation(errors, "Compile errors");
+
+    public static ExplorerItem CreateForCompilationWarnings(IReadOnlyCollection<string> warnings)
+        => CreateForCompilation(warnings, "Compile warnings");
+
+    private static ExplorerItem CreateForCompilation(IReadOnlyCollection<string> messages, string text)
+    {
+        var errorExplorerItem = new ExplorerItem(text, ExplorerItemKind.Schema, ExplorerIcon.LinkedDatabase)
+        {
+            Children = new List<ExplorerItem>(messages.Count)
+        };
+
+        foreach (var message in messages)
+        {
+            errorExplorerItem.Children.Add(new ExplorerItem(message, ExplorerItemKind.Schema, ExplorerIcon.Inherited)
+            {
+                DragText = message,
+                ToolTipText = message
+            });
+        }
+
+        return errorExplorerItem;
+    }
+
+    public static ExplorerItem CreateForElapsedTime(string name, TimeSpan elapsed)
+        => new(name + " " + elapsed, ExplorerItemKind.Property, ExplorerIcon.Blank);
+
+    public static List<ExplorerItem> CreateForGeneratedCode(string codeGeneratedByNSwag, string clientSourceCode)
+        => new()
+        {
+            new("NSwag generated source code", ExplorerItemKind.Schema, ExplorerIcon.Schema)
+            {
+                ToolTipText = "Drag and drop context generated source code to text window",
+                DragText = codeGeneratedByNSwag
+            },
+            new("Client source code", ExplorerItemKind.Schema, ExplorerIcon.Schema)
+            {
+                ToolTipText = "Drag and drop context source code to text window client",
+                DragText = clientSourceCode
+            }
+        };
+}

--- a/OpenApiLINQPadDriver/Extensions/AssemblyExtensions.cs
+++ b/OpenApiLINQPadDriver/Extensions/AssemblyExtensions.cs
@@ -2,9 +2,8 @@
 using System.Reflection;
 
 namespace OpenApiLINQPadDriver.Extensions;
-
 internal static class AssemblyExtensions
 {
-    public static Type GetType(this Assembly assembly, string nameSpace, string typeName)
-        => assembly.GetType(nameSpace + "." + typeName, true)!;
+    public static Type GetType(this Assembly assembly, TypeDescriptor type)
+        => assembly.GetType(type.ToString(), true)!;
 }

--- a/OpenApiLINQPadDriver/Extensions/StringExtensions.cs
+++ b/OpenApiLINQPadDriver/Extensions/StringExtensions.cs
@@ -3,8 +3,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace OpenApiLINQPadDriver.Extensions;
-
-public static class StringExtensions
+internal static class StringExtensions
 {
     public static bool? ToBoolSafe(this string? s, NumberStyles style = NumberStyles.Integer | NumberStyles.AllowThousands, IFormatProvider? provider = null)
     {
@@ -17,12 +16,12 @@ public static class StringExtensions
                 : null;
     }
 
-    public static long? ToLongSafe(this string? s, NumberStyles style = NumberStyles.Integer | NumberStyles.AllowThousands, IFormatProvider? provider = null) 
+    public static long? ToLongSafe(this string? s, NumberStyles style = NumberStyles.Integer | NumberStyles.AllowThousands, IFormatProvider? provider = null)
         => long.TryParse(s, style, provider.ResolveFormatProvider(), out var parsedValue) ? parsedValue : null;
 
     public static readonly IFormatProvider DefaultFormatProvider = CultureInfo.InvariantCulture;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static IFormatProvider ResolveFormatProvider(this IFormatProvider? provider) =>
-        provider ?? DefaultFormatProvider;
+    private static IFormatProvider ResolveFormatProvider(this IFormatProvider? provider)
+        => provider ?? DefaultFormatProvider;
 }

--- a/OpenApiLINQPadDriver/OpenApiContextDriver.cs
+++ b/OpenApiLINQPadDriver/OpenApiContextDriver.cs
@@ -6,9 +6,11 @@ using System.Reflection;
 using LINQPad.Extensibility.DataContext;
 
 namespace OpenApiLINQPadDriver;
+// ReSharper disable once UnusedMember.Global
 public class OpenApiContextDriver : DynamicDataContextDriver
 {
 #if DEBUG_PUBLISH_TO_LINQPAD_FOLDER
+    private const string DriverName = "OpenApi Driver from folder";
     public OpenApiContextDriver()
     {
         AppDomain.CurrentDomain.FirstChanceException += (_, args) =>
@@ -17,6 +19,8 @@ public class OpenApiContextDriver : DynamicDataContextDriver
                 Debugger.Launch();
         };
     }
+#else
+    private const string DriverName = "OpenApi Driver";
 #endif
 
     public override string GetConnectionDescription(IConnectionInfo cxInfo)
@@ -38,7 +42,7 @@ public class OpenApiContextDriver : DynamicDataContextDriver
         return true;
     }
 
-    public override string Name => "OpenApi Driver";
+    public override string Name => DriverName;
 
     // ReSharper disable StringLiteralTypo
     public override string Author => "Damian Romanowski (romfir22@gmail.com)";

--- a/OpenApiLINQPadDriver/OpenApiContextDriverProperties.cs
+++ b/OpenApiLINQPadDriver/OpenApiContextDriverProperties.cs
@@ -13,6 +13,11 @@ public class OpenApiContextDriverProperties : BaseViewModel
 {
     private readonly IConnectionInfo _connectionInfo;
     private readonly XElement _driverData;
+#if DEBUG_PUBLISH_TO_LINQPAD_FOLDER
+    private const bool DefaultDebugInfo = true;
+#else
+    private const bool DefaultDebugInfo = false;
+#endif
 
     public OpenApiContextDriverProperties(IConnectionInfo connectionInfo)
     {
@@ -66,6 +71,12 @@ public class OpenApiContextDriverProperties : BaseViewModel
         set => SetValue(value);
     }
 
+    public bool BuildInRelease
+    {
+        get => GetValue(false);
+        set => SetValue(value);
+    }
+
     public bool Persist
     {
         get => GetValue(true);
@@ -80,7 +91,7 @@ public class OpenApiContextDriverProperties : BaseViewModel
 
     public bool DebugInfo
     {
-        get => GetValue(false);
+        get => GetValue(DefaultDebugInfo);
         set => SetValue(value);
     }
 
@@ -93,15 +104,15 @@ public class OpenApiContextDriverProperties : BaseViewModel
     private T GetValue<T>(Func<string?, T> convert, T defaultValue, [CallerMemberName] string callerMemberName = "")
         => convert(_driverData.Element(callerMemberName)?.Value) ?? defaultValue;
 
-    private bool GetValue(bool defaultValue, [CallerMemberName] string callerMemberName = "") =>
-        GetValue(static v => v.ToBoolSafe(), defaultValue, callerMemberName)!.Value;
+    private bool GetValue(bool defaultValue, [CallerMemberName] string callerMemberName = "")
+        => GetValue(static v => v.ToBoolSafe(), defaultValue, callerMemberName)!.Value;
 
-    private string? GetValue(string defaultValue, [CallerMemberName] string callerMemberName = "") =>
-        GetValue(static v => v, defaultValue, callerMemberName);
+    private string? GetValue(string defaultValue, [CallerMemberName] string callerMemberName = "")
+        => GetValue(static v => v, defaultValue, callerMemberName);
 
     private T GetValue<T>(T defaultValue, [CallerMemberName] string callerMemberName = "")
-        where T : Enum
-        => (T)GetValue(v => Enum.TryParse(typeof(T), v, out var val) ? val : defaultValue, defaultValue, callerMemberName)!;
+        where T : struct, Enum
+        => (T)GetValue(v => Enum.TryParse<T>(v, out var val) ? val : defaultValue, defaultValue, callerMemberName);
 
     private void SetValue<T>(T value, [CallerMemberName] string callerMemberName = "")
     {

--- a/OpenApiLINQPadDriver/OpenApiContextDriverPropertiesEqualityComparer.cs
+++ b/OpenApiLINQPadDriver/OpenApiContextDriverPropertiesEqualityComparer.cs
@@ -4,13 +4,13 @@ namespace OpenApiLINQPadDriver;
 internal sealed class OpenApiContextDriverPropertiesEqualityComparer : IEqualityComparer<OpenApiContextDriverProperties>
 {
     public static readonly OpenApiContextDriverPropertiesEqualityComparer Default = new();
-    
+
     public bool Equals(OpenApiContextDriverProperties? x, OpenApiContextDriverProperties? y)
     {
-        if (ReferenceEquals(x, y)) 
+        if (ReferenceEquals(x, y))
             return true;
 
-        if (x is null || y is null) 
+        if (x is null || y is null)
             return false;
 
         return x.OpenApiDocumentUri == y.OpenApiDocumentUri
@@ -18,7 +18,9 @@ internal sealed class OpenApiContextDriverPropertiesEqualityComparer : IEquality
                && x.EndpointGrouping == y.EndpointGrouping
                && x.JsonLibrary == y.JsonLibrary
                && x.ClassStyle == y.ClassStyle
-               && x.GenerateSyncMethods == y.GenerateSyncMethods;
+               && x.GenerateSyncMethods == y.GenerateSyncMethods
+               && x.DebugInfo == y.DebugInfo
+               && x.BuildInRelease == y.BuildInRelease;
     }
 
     public int GetHashCode(OpenApiContextDriverProperties obj)

--- a/OpenApiLINQPadDriver/OpenApiDocumentHelper.cs
+++ b/OpenApiLINQPadDriver/OpenApiDocumentHelper.cs
@@ -9,4 +9,7 @@ internal static class OpenApiDocumentHelper
         => uri.Scheme == Uri.UriSchemeFile
             ? OpenApiDocument.FromFileAsync(uri.LocalPath)
             : OpenApiDocument.FromUrlAsync(uri.ToString());
+
+    public static OpenApiDocument GetFromUri(Uri uri)
+        => AsyncHelper.RunSync(() => GetFromUriAsync(uri));
 }

--- a/OpenApiLINQPadDriver/OpenApiLINQPadDriver.csproj
+++ b/OpenApiLINQPadDriver/OpenApiLINQPadDriver.csproj
@@ -61,10 +61,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="LINQPad.Reference" Version="1.3.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="NJsonSchema" Version="10.9.0" />
@@ -73,6 +69,11 @@
 		<PackageReference Include="NSwag.CodeGeneration" Version="13.20.0" />
 		<PackageReference Include="NSwag.CodeGeneration.CSharp" Version="13.20.0" />
 		<PackageReference Include="NSwag.Core" Version="13.20.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.7.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/OpenApiLINQPadDriver/OpenApiLINQPadDriver.csproj
+++ b/OpenApiLINQPadDriver/OpenApiLINQPadDriver.csproj
@@ -19,7 +19,7 @@
 
 	<PropertyGroup>
 		<AssemblyName>OpenApiLINQPadDriver</AssemblyName>
-		<Version>0.0.3-alpha</Version>
+		<Version>0.0.4-alpha</Version>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Authors>Damian Romanowski (romfir22@gmail.com)</Authors>
 		<Copyright>Copyright © Damian Romanowski 2023-$([System.DateTime]::Now.Year)</Copyright>

--- a/OpenApiLINQPadDriver/TypeDescriptor.cs
+++ b/OpenApiLINQPadDriver/TypeDescriptor.cs
@@ -1,0 +1,14 @@
+﻿namespace OpenApiLINQPadDriver;
+internal sealed class TypeDescriptor
+{
+    public string Name { get; }
+    public string NameSpace { get; }
+
+    public TypeDescriptor(string name, string nameSpace)
+    {
+        Name = name;
+        NameSpace = nameSpace;
+    }
+
+    public override string ToString() => NameSpace + "." + Name;
+}

--- a/OpenApiLINQPadDriver/packages.lock.json
+++ b/OpenApiLINQPadDriver/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "1.3.0",
         "contentHash": "1X8IUFMmnIXPcGLPtv3bBcJa/vhRmvI1aKAGh6Enrs7FHnqkXvA3w5j6v91XxQkBtG+DjHmg4M9/eeP/jPFCew=="
       },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "JHCP2L6lB0oJ3tQoHkC67SFZxW+KbJVOnAo+6L01K5r/NlBlSUhTk5nUAldWhTVwGdzqNeHqGtnEqpsCmGSwQA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[4.7.0]"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[1.1.1, )",
@@ -103,6 +112,22 @@
         "type": "Transitive",
         "resolved": "1.1.1",
         "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.3.4",
+        "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "pD5S14xMUebSGYe75kt0q/aaS/ftvktSo/pEv7aX7hNPHfdZS+SZeXvkvcffGxWkunYOyRF9m1oN7zzSdYj9dQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "System.Collections.Immutable": "7.0.0",
+          "System.Reflection.Metadata": "7.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
@@ -386,6 +411,14 @@
           "System.Runtime.Extensions": "4.3.0",
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "dQPcs0U1IKnBdRDBkrCTi1FoajSTBzLcVTpjO4MBCMC7f4pDOIPzgBoX8JjG7X6uZRJ8EBxsi8+DR1JuwjnzOQ==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Console": {
@@ -731,6 +764,14 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "dependencies": {
+          "System.Collections.Immutable": "7.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -773,11 +814,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rcnXA1U9W3QUtMSGoyoNHH6w4V5Rxa/EKXmzpORUYlDAlDB34hIQoU57ATXl8xHa83VvzRm6PcElEizgUd7U5w==",
-        "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",
@@ -1108,6 +1146,15 @@
         "resolved": "1.3.0",
         "contentHash": "1X8IUFMmnIXPcGLPtv3bBcJa/vhRmvI1aKAGh6Enrs7FHnqkXvA3w5j6v91XxQkBtG+DjHmg4M9/eeP/jPFCew=="
       },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Direct",
+        "requested": "[4.7.0, )",
+        "resolved": "4.7.0",
+        "contentHash": "JHCP2L6lB0oJ3tQoHkC67SFZxW+KbJVOnAo+6L01K5r/NlBlSUhTk5nUAldWhTVwGdzqNeHqGtnEqpsCmGSwQA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Common": "[4.7.0]"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[1.1.1, )",
@@ -1203,6 +1250,22 @@
         "type": "Transitive",
         "resolved": "1.1.1",
         "contentHash": "AT3HlgTjsqHnWpBHSNeR0KxbLZD7bztlZVj7I8vgeYG9SYqbeFGh0TM/KVtC6fg53nrWHl3VfZFvb5BiQFcY6Q=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.3.4",
+        "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "pD5S14xMUebSGYe75kt0q/aaS/ftvktSo/pEv7aX7hNPHfdZS+SZeXvkvcffGxWkunYOyRF9m1oN7zzSdYj9dQ==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "System.Collections.Immutable": "7.0.0",
+          "System.Reflection.Metadata": "7.0.0",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
@@ -1487,6 +1550,11 @@
           "System.Threading": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
         }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "dQPcs0U1IKnBdRDBkrCTi1FoajSTBzLcVTpjO4MBCMC7f4pDOIPzgBoX8JjG7X6uZRJ8EBxsi8+DR1JuwjnzOQ=="
       },
       "System.Console": {
         "type": "Transitive",
@@ -1831,6 +1899,14 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "dependencies": {
+          "System.Collections.Immutable": "7.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1873,11 +1949,8 @@
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rcnXA1U9W3QUtMSGoyoNHH6w4V5Rxa/EKXmzpORUYlDAlDB34hIQoU57ATXl8xHa83VvzRm6PcElEizgUd7U5w==",
-        "dependencies": {
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Runtime.Extensions": {
         "type": "Transitive",

--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ async Task Main()
     * `Classes implementing the Prism base class` - WIP, the library that is required is not added to the compilation
     * `Records - read only POCOs (Plain Old C# Objects)`
 * Generate sync methods - by default sync methods will not be generated
+* Build in Release - Build generated code in Release, default: `false`
 
 ### Misc ###
 
-* Debug info: show additional driver debug info, e.g. generated data context sources and add `Execution Times` explorer item with exectuion times of parts of the generation pipeline
+* Debug info: show additional driver debug info, e.g. generated data context sources, add `Execution Times` explorer item with execution times of parts of the generation pipeline and will add warnings from the compilation if any were present
 * Remember this connection: connection will be available on next run.
 * Contains production data: files contain production data.
 
@@ -159,6 +160,7 @@ https://github.com/romfir/OpenApiLINQPadDriver/blob/master/OpenApiLINQPadDriver/
 * Add `Prism.Mvvm` to compilation when prism class style is picked
 * When multiple servers are found allow selection
 * LINQPad 5 support
-* Examples (include in the nuget)
+* Examples (include in the nuget) - possibly the same ones could be used in testing
 * Expose JsonSerializerSettings setter on multi client setup
 * Expose ReadResponseAsString on multi client setup
+* Treat warnings as errors in generated code (`generalDiagnosticOption: ReportDiagnostic.Error`)


### PR DESCRIPTION
* Added manual compilation instead of using LINQPad's DataContextDriver.CompileSource with additional generation of XML documentation whitch LINQPad can consume

* Warnings will be displayed in debug mode

* Added an option to build generated code in Release mode

* Made most of the classes internal so they won't be visible inside LINQPad query